### PR TITLE
Snyk Vulnerabilities Remediation from "vulnerable.tf" file | CS2-233

### DIFF
--- a/snyk-tests/vulnerable.tf
+++ b/snyk-tests/vulnerable.tf
@@ -22,11 +22,12 @@ resource "aws_ebs_volume" "example" {
 
 
 resource "aws_lb" "test" {
-  name               = "test-lb-tf"
-  internal           = false
-  load_balancer_type = "application"
-  security_groups    = [aws_security_group.lb_sg.id]
-  subnets            = [for subnet in aws_subnet.public : subnet.id]
+  name                       = "test-lb-tf"
+  internal                   = false
+  load_balancer_type         = "application"
+  security_groups            = [aws_security_group.lb_sg.id]
+  subnets                    = [for subnet in aws_subnet.public : subnet.id]
+  drop_invalid_header_fields = true
 
   enable_deletion_protection = false
 
@@ -38,8 +39,8 @@ resource "aws_lb" "test" {
 resource "aws_lb_listener" "front_end" {
   load_balancer_arn = aws_lb.front_end.arn
   # port              = "80"
-  port              = "443"   
-  protocol          = "HTTPS"         # this is to resolve the snyk critical severity vulnerability
+  port     = "443"
+  protocol = "HTTPS" # this is to resolve the snyk critical severity vulnerability
   default_action {
     type             = "forward"
     target_group_arn = aws_lb_target_group.front_end.arn

--- a/snyk-tests/vulnerable.tf
+++ b/snyk-tests/vulnerable.tf
@@ -14,6 +14,7 @@ resource "aws_s3_bucket_public_access_block" "example" {
 resource "aws_ebs_volume" "example" {
   availability_zone = "us-west-2a"
   size              = 40
+  encrypted         = true
 
   tags = {
     Name = "HelloWorld"

--- a/snyk-tests/vulnerable.tf
+++ b/snyk-tests/vulnerable.tf
@@ -37,8 +37,9 @@ resource "aws_lb" "test" {
 
 resource "aws_lb_listener" "front_end" {
   load_balancer_arn = aws_lb.front_end.arn
-  port              = "80"
-  protocol          = "HTTP"
+  # port              = "80"
+  port              = "443"   
+  protocol          = "HTTPS"         # this is to resolve the snyk critical severity vulnerability
   default_action {
     type             = "forward"
     target_group_arn = aws_lb_target_group.front_end.arn

--- a/snyk-tests/vulnerable.tf
+++ b/snyk-tests/vulnerable.tf
@@ -6,7 +6,7 @@ resource "aws_s3_bucket_public_access_block" "example" {
   bucket = aws_s3_bucket.example.id
 
   block_public_acls       = true
-  block_public_policy     = false
+  block_public_policy     = true
   ignore_public_acls      = false
   restrict_public_buckets = false
 }

--- a/snyk-tests/vulnerable.tf
+++ b/snyk-tests/vulnerable.tf
@@ -7,7 +7,7 @@ resource "aws_s3_bucket_public_access_block" "example" {
 
   block_public_acls       = true
   block_public_policy     = true
-  ignore_public_acls      = false
+  ignore_public_acls      = true
   restrict_public_buckets = false
 }
 

--- a/snyk-tests/vulnerable.tf
+++ b/snyk-tests/vulnerable.tf
@@ -8,7 +8,7 @@ resource "aws_s3_bucket_public_access_block" "example" {
   block_public_acls       = true
   block_public_policy     = true
   ignore_public_acls      = true
-  restrict_public_buckets = false
+  restrict_public_buckets = true
 }
 
 resource "aws_ebs_volume" "example" {

--- a/snyk-tests/vulnerable.tf
+++ b/snyk-tests/vulnerable.tf
@@ -5,7 +5,7 @@ resource "aws_s3_bucket" "example" {
 resource "aws_s3_bucket_public_access_block" "example" {
   bucket = aws_s3_bucket.example.id
 
-  block_public_acls       = false
+  block_public_acls       = true
   block_public_policy     = false
   ignore_public_acls      = false
   restrict_public_buckets = false


### PR DESCRIPTION
This PR remediates different `snyk` severity vulnerabilities generated from the `vulnerable.tf` file. 

- `Critical` -> Load balancer endpoint does not enforce HTTPS 
    - Check it out here: [SNYK-CC-TF-47](https://security.snyk.io/rules/cloud/SNYK-CC-TF-47)
    
- `High` -> ALB does not drop invalid headers 
    - Check it out here: [SNYK-CC-AWS-405](https://security.snyk.io/rules/cloud/SNYK-CC-AWS-405)
    
- `High` -> Non-encrypted EBS volume
    - Check it out here: [SNYK-CC-TF-3](https://security.snyk.io/rules/cloud/SNYK-CC-TF-3)

- `High` -> S3 block public ACLs control is disabled
    - Check it out here: [SNYK-CC-TF-95](https://security.snyk.io/rules/cloud/SNYK-CC-TF-95)

- `High` -> S3 block public policy control is disabled
    - Check it out here: [SNYK-CC-TF-96](https://security.snyk.io/rules/cloud/SNYK-CC-TF-96)

- `High` -> S3 ignore public ACLs control is disabled
    - Check it out here: [SNYK-CC-TF-97](https://security.snyk.io/rules/cloud/SNYK-CC-TF-97)

- `High` -> S3 restrict public bucket control is disabled
    - Check it out here: [SNYK-CC-TF-98](https://security.snyk.io/rules/cloud/SNYK-CC-TF-98)