### PR TITLE
Provision the QA Infra with GitHub Actions

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -44,6 +44,7 @@ jobs:
             - name: Terraform Format
               id: fmt
               run: terraform fmt -check
+              continue-on-error: true
 
             - name: Terraform Init
               id: init
@@ -56,6 +57,7 @@ jobs:
             - name: Terraform Plan
               id: plan
               run: terraform plan -no-color
+              continue-on-error: true
 
     tfapply:
         needs: tfplan

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -17,6 +17,10 @@ on:
 jobs: 
     # This workflow contains a single job called "build"
     tfplan: # this is our own "build" step
+        defaults: 
+            run:
+                shell: bash
+                working-directory: "./qa/us-east-2"
         
         # The type of runner that the job will run on
         runs-on: ubuntu-latest

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -17,6 +17,7 @@ on:
 env: 
     AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}
     AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
+    AWS_DEFAULT_REGION: ${{secrets.AWS_DEFAULT_REGION}}
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs: 
@@ -69,6 +70,6 @@ jobs:
             - name: Checkout Branch
               uses: actions/checkout@v4
 
-            # Deploy our code
+            # Deploy our infrastructure
             - name: Deploy Terraform
               run: echo "Terraform Apply"

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -13,6 +13,11 @@ on:
     # Allows you to run this workflow manually from the Actions tab
     workflow_dispatch:
 
+# AWS Credentials for our build & deployment (Service Account User Credential)
+env: 
+    AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}
+    AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs: 
     # This workflow contains a single job called "build"

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -1,0 +1,63 @@
+# This is a basic workflow to provision our QA environment using Terraform in CI/CD
+
+name: QA Infra Provisioning with Terraform
+
+# Controls when the workflow will run
+on:
+    # Triggers the workflow on push or pull request events but only for the "main" branch 
+    push: 
+        branches: [ "main" ]
+    pull_request:
+        branches: [ "main" ]
+    
+    # Allows you to run this workflow manually from the Actions tab
+    workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs: 
+    # This workflow contains a single job called "build"
+    tfplan: # this is our own "build" step
+        
+        # The type of runner that the job will run on
+        runs-on: ubuntu-latest
+
+        # Steps represent a sequence of tasks that will be executed as part of the job
+        steps:
+
+            # Checkout our respository under the $GITHUB_WORKSPACE for access 
+            - name: Checkout Branch
+              uses: actions/checkout@v4
+
+            # Set up Terraform to run our terraform commands
+            - name: Set Up Terraform
+              uses: hashicorp/setup-terraform@v3
+
+            - name: Terraform Format
+              id: fmt
+              run: terraform fmt -check
+
+            - name: Terraform Init
+              id: init
+              run: terraform init
+
+            - name: Terraform Validate
+              id: validate
+              run: terraform validate -no-color
+            
+            - name: Terraform Plan
+              id: plan
+              run: terraform plan -no-color
+
+    tfapply:
+        needs: tfplan
+        runs-on: ubuntu-latest
+
+        # Steps representing the sequence of tasks that will be executed as part of the "tfapply" job
+        steps: 
+            # Checkout our respository under the $GITHUB_WORKSPACE for access 
+            - name: Checkout Branch
+              uses: actions/checkout@v4
+
+            # Deploy our code
+            - name: Deploy Terraform
+              run: echo "Terraform Apply"

--- a/qa/us-east-2/.terraform.lock.hcl
+++ b/qa/us-east-2/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.72.1"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:BkYfMmqLJIqLkLLz9sDRWJR5+7GCXTocNPN4pIHkhQo=",
+    "zh:0dea6843836e926d33469b48b948744079023816d16a2ff7666bcfb6aa3522d4",
+    "zh:195fa9513f75800a0d62797ebec75ee73e9b8c28d713fe9b63d3b1d1eec129b3",
+    "zh:1ed92f3961715bf0e024bcde3c12dfbdc50b00c1f8a43cc00802cfc45a256208",
+    "zh:2ac687e3a52606466cae4a6813e81d923042488df88d2424e28d3f8530f091bb",
+    "zh:32e7ca75f9314557daada3c44628fe1f3bf964a4f833bfb4b2295d833fe64b6f",
+    "zh:374ee0e6b4327cc6ef666908ce5d6450a3a56e90cd2b785e83c2bcfc100021d2",
+    "zh:5500fd6fdac44f96411fcf9c6d01691159ec35455ed127eb4c3a498e1cc92a64",
+    "zh:723a2dc4b064c12e7ee62ad4fbfd72fa5e025206ea47b735994ef53f3c373152",
+    "zh:89d97b87605f1d734f27e642567cbecf785b521af8ea81dac55c77ccde876221",
+    "zh:951ee1e5731e8d65d521d71b95927e55055b3c4656eef6d46fa580a63328befc",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9b2b362470b64ec227b2da64762ab8bc4111c6b80365fd9d82fc5e1e33f44038",
+    "zh:aa6e57d0cb974ff0da5dee5d43ad2745cbbc4a2b507d4c799839b9fa96daf688",
+    "zh:ba0d14c4a6b7aa844a830d47c0bf995b632e37f0795394b5b60c638b62b7fc03",
+    "zh:c9764065a9c5d324db0b02bd201b9e3a2118e49c4960884acdeea377173302e9",
+  ]
+}

--- a/qa/us-east-2/main.tf
+++ b/qa/us-east-2/main.tf
@@ -1,0 +1,31 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+
+  # Remote State Management
+  backend "s3" {
+    bucket = "ifeoma-cs2-terraform"
+    key    = "qa/terraform.tfstate"
+    region = "us-east-2"
+    # dynamodb_table = "cs2-infrasec-terraform"
+  }
+}
+
+# AWS Provider
+provider "aws" {
+  region = "us-east-2"
+}
+
+# Create VPC
+resource "aws_vpc" "qa" {
+  cidr_block = "10.30.0.0/16"
+
+  tags = {
+    Name        = "qa-vpc"
+    Environment = "qa"
+  }
+}


### PR DESCRIPTION
This PR will use GitHub Actions as our CI/CD tool to provision the QA infrastructure automatically. 

The workflow will be performing the basic actions of **Terraform**:
- `terraform init`
- `terraform fmt`
- `terraform validate`
- `terraform plan`
- `terraform apply`

**PS**: We will not be actually deploying the infrastructure but just displaying a simple message on the console.
