### PR TITLE
Fixed the deploy step to run job on merge event

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -142,7 +142,10 @@ jobs:
     # Deploy Step
     tfapply:
       ## Only Run TF Apply when a PR is merged
-      if: github.event_name == 'push'
+
+      # always run when there is a merge event irrespective of whether the scan job ran or not
+      # this is assuming all security scan was remediated (if any) before merge
+      if: always() && github.event_name == 'push'    
 
       needs: terraform-snyk-scan
       runs-on: ubuntu-latest


### PR DESCRIPTION
This PR fixes the `tfapply` job to run when there is a merge event which is a `push`. 
- Now the `tfapply` job should run when I merge the PR