### PR TITLE
Staging Deployment with CI/CD

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -19,6 +19,12 @@ env:
     AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
     AWS_DEFAULT_REGION: ${{secrets.AWS_DEFAULT_REGION}}
 
+# We want this applied to all jobs
+defaults: 
+    run:
+        shell: bash
+        working-directory: "./staging/us-east-2"
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs: 
     # This workflow contains a single job called "build"
@@ -26,11 +32,6 @@ jobs:
 
       ## Only Run TF Plan when a PR is opened
       if: github.event_name == 'pull_request'
-
-      defaults: 
-          run:
-              shell: bash
-              working-directory: "./qa/us-east-2"
       
       # The type of runner that the job will run on
       runs-on: ubuntu-latest
@@ -136,7 +137,7 @@ jobs:
           env:
             SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
           with:
-            file: "./qa/us-east-2"
+            file: "./staging/us-east-2"
             args: --severity-threshold=high    # only break pipeline for any 'high' vulnerabilities detected
 
     # Deploy Step

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -1,6 +1,6 @@
 # This is a basic workflow to provision our QA environment using Terraform in CI/CD
 
-name: QA Infra Provisioning with Terraform
+name: Staging Infra Provisioning with Terraform
 
 # Controls when the workflow will run
 on:
@@ -156,6 +156,14 @@ jobs:
           - name: Checkout Branch
             uses: actions/checkout@v4
 
+          # Set up Terraform to run our terraform commands
+          - name: Set Up Terraform
+            uses: hashicorp/setup-terraform@v3
+
+          - name: Terraform Init
+            id: init
+            run: terraform init
+
           # Deploy our infrastructure
           - name: Deploy Terraform
-            run: echo "Terraform Apply"
+            run: terraform apply -auto-approve

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -50,7 +50,7 @@ jobs:
           - name: Terraform Format
             id: fmt
             run: terraform fmt -check
-            continue-on-error: true
+            # continue-on-error: true
 
           - name: Terraform Init
             id: init

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -167,3 +167,29 @@ jobs:
           # Deploy our infrastructure
           - name: Deploy Terraform
             run: terraform apply -auto-approve
+
+    # Destroy the infrastructure
+    tfdestroy:
+      ## Only Run TF Destroy when the pipeline is triggered manually 
+      if: always() && github.event_name == 'workflow_dispatch'    
+
+      needs: tfapply
+      runs-on: ubuntu-latest
+
+      # Steps representing the sequence of tasks that will be executed as part of the "tfapply" job
+      steps: 
+          # Checkout our respository under the $GITHUB_WORKSPACE for access 
+          - name: Checkout Branch
+            uses: actions/checkout@v4
+
+          # Set up Terraform to run our terraform commands
+          - name: Set Up Terraform
+            uses: hashicorp/setup-terraform@v3
+
+          - name: Terraform Init
+            id: init
+            run: terraform init
+
+          # Deploy our infrastructure
+          - name: Deploy Terraform
+            run: terraform destroy -auto-approve

--- a/staging/us-east-2/vpc.tf
+++ b/staging/us-east-2/vpc.tf
@@ -1,6 +1,6 @@
 module "staging" {
   # this module now uses the published module in "ifeoma-tf-modules" repo
-  source = "github.com/fojiglobal/ifeoma-tf-modules//staging?ref=v1.0.0" 
+  source = "github.com/fojiglobal/ifeoma-tf-modules//staging?ref=v1.0.0"
 
   # these are the variable names in variables.tf "/modules" folder
   vpc_cidr        = local.vpc_cidr_block


### PR DESCRIPTION
This PR will be used to deploy our `staging` infrastructure with a CI/CD pipeline. 

- Renamed our existing pipeline configuration file from `qa.yml` to `staging.yml` file
- Modified our `tfapply` job to now deploy our staging infrastructure
- Added a `destroy` job to de-provision our infrastructure after deployment using manual trigger only
- Updated the `working-directory` of our configuration to point to the `staging` directory
- Added a `default` shell to run our terraform scripts 
- Commented out `continue-on-error` on our `terraform format` step for best practices. It is not advisable to continue running the pipeline after it has encountered an error