### PR TITLE
AWS Organizations with Terraform

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -19,6 +19,12 @@ env:
     AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
     AWS_DEFAULT_REGION: ${{secrets.AWS_DEFAULT_REGION}}
 
+# We want this applied to all jobs
+defaults: 
+    run:
+        shell: bash
+        working-directory: "./staging/us-east-2"
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs: 
     # This workflow contains a single job called "build"
@@ -26,11 +32,6 @@ jobs:
 
       ## Only Run TF Plan when a PR is opened
       if: github.event_name == 'pull_request'
-
-      defaults: 
-          run:
-              shell: bash
-              working-directory: "./qa/us-east-2"
       
       # The type of runner that the job will run on
       runs-on: ubuntu-latest
@@ -136,7 +137,7 @@ jobs:
           env:
             SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
           with:
-            file: "./qa/us-east-2"
+            file: "./staging/us-east-2"
             args: --severity-threshold=high    # only break pipeline for any 'high' vulnerabilities detected
 
     # Deploy Step

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -1,6 +1,6 @@
 # This is a basic workflow to provision our QA environment using Terraform in CI/CD
 
-name: QA Infra Provisioning with Terraform
+name: Staging Infra Provisioning with Terraform
 
 # Controls when the workflow will run
 on:
@@ -156,6 +156,14 @@ jobs:
           - name: Checkout Branch
             uses: actions/checkout@v4
 
+          # Set up Terraform to run our terraform commands
+          - name: Set Up Terraform
+            uses: hashicorp/setup-terraform@v3
+
+          - name: Terraform Init
+            id: init
+            run: terraform init
+
           # Deploy our infrastructure
           - name: Deploy Terraform
-            run: echo "Terraform Apply"
+            run: terraform apply -auto-approve

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -50,7 +50,7 @@ jobs:
           - name: Terraform Format
             id: fmt
             run: terraform fmt -check
-            continue-on-error: true
+            # continue-on-error: true
 
           - name: Terraform Init
             id: init

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -167,3 +167,29 @@ jobs:
           # Deploy our infrastructure
           - name: Deploy Terraform
             run: terraform apply -auto-approve
+
+    # Destroy the infrastructure
+    tfdestroy:
+      ## Only Run TF Destroy when the pipeline is triggered manually 
+      if: always() && github.event_name == 'workflow_dispatch'    
+
+      needs: tfapply
+      runs-on: ubuntu-latest
+
+      # Steps representing the sequence of tasks that will be executed as part of the "tfapply" job
+      steps: 
+          # Checkout our respository under the $GITHUB_WORKSPACE for access 
+          - name: Checkout Branch
+            uses: actions/checkout@v4
+
+          # Set up Terraform to run our terraform commands
+          - name: Set Up Terraform
+            uses: hashicorp/setup-terraform@v3
+
+          - name: Terraform Init
+            id: init
+            run: terraform init
+
+          # Deploy our infrastructure
+          - name: Deploy Terraform
+            run: terraform destroy -auto-approve

--- a/aws-org/.terraform.lock.hcl
+++ b/aws-org/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.74.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:HMaN/L2hf1PN2YLdlQRbE49f4RF7VuqEVpqxNtJ2+18=",
+    "zh:1e2d65add4d63af5b396ae33d55c48303eca6c86bd1be0f6fae13267a9b47bc4",
+    "zh:20ddec3dac3d06a188f12e58b6428854949b1295e937c5d4dca4866dc1c937af",
+    "zh:35b72de4e6a3e3d69efc07184fb413406262fe447b2d82d57eaf8c787a068a06",
+    "zh:44eada24a50cd869aadc4b29f9e791fdf262d7f426921e9ac2893bbb86013176",
+    "zh:455e666e3a9a2312b3b9f434b87a404b6515d64a8853751e20566a6548f9df9e",
+    "zh:58b3ae74abfca7b9b61f42f0c8b10d97f9b01aff18bd1d4ab091129c9d203707",
+    "zh:840a8a32d5923f9e7422f9c80d165c3f89bb6ea370b8283095081e39050a8ea8",
+    "zh:87cb6dbbdbc1b73bdde4b8b5d6d780914a3e8f1df0385da4ea7323dc1a68468f",
+    "zh:8b8953e39b0e6e6156c5570d1ca653450bfa0d9b280e2475f01ee5c51a6554db",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9bd750262e2fb0187a8420a561e55b0a1da738f690f53f5c7df170cb1f380459",
+    "zh:9d2474c1432dfa5e1db197e2dd6cd61a6a15452e0bc7acd09ca86b3cdb228871",
+    "zh:b763ecaf471c7737a5c6e4cf257b5318e922a6610fd83b36ed8eb68582a8642e",
+    "zh:c1344cd8fe03ff7433a19b14b14a1898c2ca5ba22a468fb8e1687f0a7f564d52",
+    "zh:dc0e0abf3be7402d0d022ced82816884356115ed27646df9c7222609e96840e6",
+  ]
+}

--- a/aws-org/aws-org.tf
+++ b/aws-org/aws-org.tf
@@ -1,0 +1,8 @@
+resource "aws_organizations_organization" "org" {
+  aws_service_access_principals = [
+    "cloudtrail.amazonaws.com",
+    "config.amazonaws.com",
+  ]
+
+  feature_set = "ALL"
+}

--- a/aws-org/aws-org.tf
+++ b/aws-org/aws-org.tf
@@ -12,10 +12,12 @@ resource "aws_organizations_organization" "org" {
 resource "aws_organizations_account" "cs2-sandbox" {
   name  = "cs2-sandbox"
   email = "alearning58+cs2sandbox@gmail.com"
+  parent_id = aws_organizations_organizational_unit.cs2-sandbox.id
 }
 
 # AWS Organization Account - 'CS2-Secops' 
 resource "aws_organizations_account" "cs2-secops" {
   name  = "cs2-secops"
   email = "alearning58+cs2secops@gmail.com"
+  parent_id = aws_organizations_organizational_unit.cs2-secops.id
 }

--- a/aws-org/aws-org.tf
+++ b/aws-org/aws-org.tf
@@ -21,3 +21,14 @@ resource "aws_organizations_account" "cs2-secops" {
   email = "alearning58+cs2secops@gmail.com"
   parent_id = aws_organizations_organizational_unit.cs2-secops.id
 }
+
+# Import AWS SSO Permission set 
+resource "aws_ssoadmin_permission_set" "admin-permission" {
+  name             = "AdministratorAccess"
+  instance_arn     = tolist(data.aws_ssoadmin_instances.fojiglobal.arns)[0]
+}
+
+resource "aws_ssoadmin_permission_set" "billing-permission" {
+  name             = "Billing"
+  instance_arn     = tolist(data.aws_ssoadmin_instances.fojiglobal.arns)[0]
+}

--- a/aws-org/aws-org.tf
+++ b/aws-org/aws-org.tf
@@ -13,3 +13,9 @@ resource "aws_organizations_account" "cs2-sandbox" {
   name  = "cs2-sandbox"
   email = "alearning58+cs2sandbox@gmail.com"
 }
+
+# AWS Organization Account - 'CS2-Secops' 
+resource "aws_organizations_account" "cs2-secops" {
+  name  = "cs2-secops"
+  email = "alearning58+cs2secops@gmail.com"
+}

--- a/aws-org/aws-org.tf
+++ b/aws-org/aws-org.tf
@@ -1,3 +1,4 @@
+# AWS Organization
 resource "aws_organizations_organization" "org" {
   aws_service_access_principals = [
     "cloudtrail.amazonaws.com",
@@ -5,4 +6,10 @@ resource "aws_organizations_organization" "org" {
   ]
 
   feature_set = "ALL"
+}
+
+# AWS Organization Account - 'CS2-Sandbox' -> Imported
+resource "aws_organizations_account" "cs2-sandbox" {
+  name  = "cs2-sandbox"
+  email = "alearning58+cs2sandbox@gmail.com"
 }

--- a/aws-org/aws-ous.tf
+++ b/aws-org/aws-ous.tf
@@ -1,0 +1,11 @@
+# AWS Organizations Organizational Units
+
+resource "aws_organizations_organizational_unit" "cs2-sandbox" {
+  name      = "sandbox"
+  parent_id = aws_organizations_organization.org.roots[0].id
+}
+
+resource "aws_organizations_organizational_unit" "cs2-secops" {
+  name      = "secops"
+  parent_id = aws_organizations_organization.org.roots[0].id
+}

--- a/aws-org/imports.tf
+++ b/aws-org/imports.tf
@@ -1,0 +1,4 @@
+import {
+  to = aws_organizations_account.cs2-sandbox
+  id = "050451401939"
+}

--- a/aws-org/imports.tf
+++ b/aws-org/imports.tf
@@ -1,4 +1,23 @@
+# Get SSO information 
+data "aws_ssoadmin_instances" "fojiglobal" {}
+
+output "arn" {
+  value = tolist(data.aws_ssoadmin_instances.fojiglobal.arns)[0]
+}
+
+# Import AWS Account within an Organization
 import {
   to = aws_organizations_account.cs2-sandbox
   id = "050451401939"
+}
+
+# Import SSO Permission Sets
+import {
+  to = aws_ssoadmin_permission_set.admin-permission
+  id = "arn:aws:sso:::permissionSet/ssoins-6684f9ed6fbd1238/ps-7cb412c40678a886,${tolist(data.aws_ssoadmin_instances.fojiglobal.arns)[0]}"
+}
+
+import {
+  to = aws_ssoadmin_permission_set.billing-permission
+  id = "arn:aws:sso:::permissionSet/ssoins-6684f9ed6fbd1238/ps-488b480a090a936b,${tolist(data.aws_ssoadmin_instances.fojiglobal.arns)[0]}"
 }

--- a/aws-org/providers.tf
+++ b/aws-org/providers.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+
+  # Remote State Management
+  backend "s3" {
+    bucket = "ifeoma-cs2-terraform"
+    key    = "aws-org/terraform.tfstate"
+    region = "us-east-2"
+    # dynamodb_table = "cs2-infrasec-terraform"
+  }
+}
+
+# AWS Provider
+provider "aws" {
+  region = "us-east-2"
+}

--- a/staging/us-east-2/vpc.tf
+++ b/staging/us-east-2/vpc.tf
@@ -1,6 +1,6 @@
 module "staging" {
   # this module now uses the published module in "ifeoma-tf-modules" repo
-  source = "github.com/fojiglobal/ifeoma-tf-modules//staging?ref=v1.0.0" 
+  source = "github.com/fojiglobal/ifeoma-tf-modules//staging?ref=v1.0.0"
 
   # these are the variable names in variables.tf "/modules" folder
   vpc_cidr        = local.vpc_cidr_block


### PR DESCRIPTION
This PR enables our AWS Organizations and creates organizational accounts & units using terraform. 

- Created our AWS Organization with `terraform`
- Imported the `cs2-sandbox` account because it was created on the console
- Added a second account, `cs2-secops` to our org
- Created `organizational units` for the respective accounts, `cs2-sandbox` & `cs2-secops`
- Linked our accounts to their respective organizational units for proper structure